### PR TITLE
Add prop types to components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
         "cypress": "^10.4.0",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
     "cypress": "^10.4.0",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router": "^6.3.0",

--- a/src/components/news-item/NewsItem.js
+++ b/src/components/news-item/NewsItem.js
@@ -2,6 +2,7 @@ import React from "react";
 import "./NewsItem.css";
 import "../shared-styles.css";
 import useDataStore from "../hooks/useDataStore";
+import PropTypes from 'prop-types';
 
 const NewsItem = ({item}) => {
 
@@ -30,6 +31,10 @@ const NewsItem = ({item}) => {
       </div>
     </div>
   )
+};
+
+NewsItem.propTypes = {
+  item: PropTypes.object
 };
 
 export default NewsItem;

--- a/src/components/shop-thing/ShopThing.js
+++ b/src/components/shop-thing/ShopThing.js
@@ -1,6 +1,7 @@
 import React from "react";
 import "./ShopThing.css"
 import "../shared-styles.css";
+import PropTypes from 'prop-types';
 
 const ShopThing = ({item}) => {
   return(
@@ -15,6 +16,10 @@ const ShopThing = ({item}) => {
       <p className="description">{item.description}</p>
     </div>
   );
+};
+
+ShopThing.propTypes = {
+  item: PropTypes.object
 };
 
 export default ShopThing;


### PR DESCRIPTION
This branch added prop types to the two components that accepted props (ShopThing and NewsItem). This was only necessary in these two files as global state was utilized for all other components.