### PR TITLE
Bug fix June 2025

### DIFF
--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -28,13 +28,14 @@ function App() {
         res.data.entries.forEach( entry => {
           if (!entry.brItems) return;
           entry.brItems.forEach(item => {
+            if (!entry.brItems || entry.brItems.length === 0) return;
             const newShopItem = {
               name: item.name,
               id: item.id,
               description: item.description,
               type: item.type.displayValue,
               price: entry.finalPrice,
-              introduction: item.introduction.text,
+              introduction: item.introduction?.text,
               rarity: item.rarity.displayValue,
               image: item.images.featured || item.images.icon || item.images.smallIcon,
               bundleName: entry.bundle?.name || 'solo',

--- a/src/components/shop-thing/ShopThing.css
+++ b/src/components/shop-thing/ShopThing.css
@@ -82,7 +82,7 @@
   background: linear-gradient(#025253ff, #5cf2f3ff);
 }
 
-.gaming-legends-series, .star-wars-series {
+.other {
   background: linear-gradient(#28085fff, #8078ffff);
 }
 

--- a/src/components/shop-thing/ShopThing.css
+++ b/src/components/shop-thing/ShopThing.css
@@ -82,7 +82,7 @@
   background: linear-gradient(#025253ff, #5cf2f3ff);
 }
 
-.gaming-legends-series {
+.gaming-legends-series, .star-wars-series {
   background: linear-gradient(#28085fff, #8078ffff);
 }
 

--- a/src/components/shop-thing/ShopThing.js
+++ b/src/components/shop-thing/ShopThing.js
@@ -7,6 +7,7 @@ const ShopThing = ({item}) => {
 
   const formatRarityClassName = (rarity) => {
     if ( rarity === 'Gaming Legends Series') return 'gaming-legends-series';
+    if ( rarity === 'Star Wars Series') return 'star-wars-series';
     return rarity.toLowerCase();
   }
   

--- a/src/components/shop-thing/ShopThing.js
+++ b/src/components/shop-thing/ShopThing.js
@@ -6,8 +6,14 @@ import PropTypes from 'prop-types';
 const ShopThing = ({item}) => {
 
   const formatRarityClassName = (rarity) => {
-    if ( rarity === 'Gaming Legends Series') return 'gaming-legends-series';
-    if ( rarity === 'Star Wars Series') return 'star-wars-series';
+    const allowedRarities = [
+      'Uncommon',
+      'Rare',
+      'Epic',
+      'Legendary',
+      'Icon',
+    ];
+    if ( !allowedRarities.includes(rarity)) return 'other';
     return rarity.toLowerCase();
   }
   


### PR DESCRIPTION
This pr adds checks to the shop fetch to make sure that the array of `brItems` has length before doing stuff with it, and ensures a text value is there before using it for the `introduction` value.
It also adds catch-all styling for unknown rarity types, the star wars series made this one weird so I figured it'd be nice to just have cute styling for all other rarity types so I don't have to keep making sure they get formatted correctly. 

On the Vercel deployment side, I've upgraded this project to run Node 20.x, looks like 16.x was deprecated in January, and 18.x is deprecated in August. 